### PR TITLE
Reuse queues

### DIFF
--- a/src/main/scala/com/quiquedeveloper/fs2/AMain.scala
+++ b/src/main/scala/com/quiquedeveloper/fs2/AMain.scala
@@ -1,22 +1,24 @@
 package com.quiquedeveloper.fs2
+
 import cats.effect.IO
 import fs2.async.mutable.Queue
-import fs2.{Scheduler, Stream}
+import fs2.{Scheduler, Stream, StreamApp}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.Random
 
-object AMain extends App {
+object AMain extends StreamApp[IO] {
   val producer: Stream[IO, Int] =
     Scheduler[IO](5).flatMap(
       scheduler =>
         scheduler
           .awakeEvery[IO](1 second)
-          .flatMap(_ =>
-            Stream.eval(IO {
+          .evalMap(_ =>
+            IO {
               Random.nextInt
-            })))
+            }))
 
   val evenQueue: Stream[IO, Queue[IO, Int]] =
     Stream.eval(fs2.async.boundedQueue[IO, Int](10))
@@ -24,17 +26,15 @@ object AMain extends App {
   val oddQueue: Stream[IO, Queue[IO, Int]] =
     Stream.eval(fs2.async.boundedQueue[IO, Int](10))
 
-  class PrintEven(input: Stream[IO, Queue[IO, Int]]) {
+  class PrintEven(inputQ: Queue[IO, Int]) {
     val start = for {
-      inputQ <- input
       element <- inputQ.dequeue
       _ <- Stream.eval(IO { println(s"im even: $element") })
     } yield ()
   }
 
-  class PrintOdd(input: Stream[IO, Queue[IO, Int]]) {
+  class PrintOdd(inputQ: Queue[IO, Int]) {
     val start = for {
-      inputQ <- input
       element <- inputQ.dequeue
       _ <- Stream.eval(IO { println(s"im even: $element") })
     } yield ()
@@ -47,9 +47,14 @@ object AMain extends App {
     _ <- Stream.eval {
       if (element % 2 == 0) evenQueueQ.enqueue1(element)
       else oddQueueQ.enqueue1(element)
-    } concurrently new PrintEven(evenQueue).start.drain concurrently new PrintOdd(
-      oddQueue).start.drain
+    } concurrently new PrintEven(evenQueueQ).start concurrently new PrintOdd(
+      oddQueueQ
+    ).start
   } yield ()
 
-  producerStream.compile.drain.unsafeRunSync()
+  override def stream(
+    args: List[String],
+    requestShutdown: IO[Unit]
+  ): Stream[IO, StreamApp.ExitCode] =
+    producerStream.drain.as(StreamApp.ExitCode.Success)
 }


### PR DESCRIPTION
plus use StreamApp, plus don't drain streams passed to `concurrently` (just for having less code)